### PR TITLE
feat: Select SQL을 생성하는 클래스

### DIFF
--- a/backend/src/query/product-image.query.ts
+++ b/backend/src/query/product-image.query.ts
@@ -49,4 +49,4 @@ class ProductImageQuery extends BaseQuery<ProductImage, number, CreateTypes> {
   }
 }
 
-export default new ProductImage();
+export default new ProductImageQuery();

--- a/backend/src/query/product-image.ts
+++ b/backend/src/query/product-image.ts
@@ -48,3 +48,5 @@ class ProductImageQuery extends BaseQuery<ProductImage, number, CreateTypes> {
     return productImage
   }
 }
+
+export default new ProductImage();

--- a/backend/src/utils/select-sql-generator.ts
+++ b/backend/src/utils/select-sql-generator.ts
@@ -1,0 +1,68 @@
+type WhereOption = {
+  column: string;
+  equalValue: string | number;
+}
+
+type OrderOption = {
+  column: string;
+  type: 'DESC' | 'ASC';
+}
+
+type JoinOption = {
+  type: 'LEFT JOIN' | 'JOIN'
+  joinTable: string;
+  joinPK: string;
+  equalColum: string;
+}
+
+class SelectSQLGenerator {
+  private whereOptions: WhereOption[] = [];
+  private orderByOptions: OrderOption[] = [];
+  private joinOptions: JoinOption[] = [];
+
+  constructor(private table: string, private attributes: string) { }
+
+  addWhere(option: WhereOption) {
+    this.whereOptions.push(option);
+  }
+
+  addOrderBy(option: OrderOption) {
+    this.orderByOptions.push(option);
+  }
+
+  addJoin(option: JoinOption) {
+    this.joinOptions.push(option);
+  }
+
+  generate() {
+    let sql = `SELECT ${this.attributes} FROM ${this.table} `;
+    if (this.joinOptions.length > 0) {
+      this.joinOptions.forEach(option => {
+        sql += ` ${option.type} ${option.joinTable} ON ${option.equalColum} = ${option.joinTable}.${option.joinPK} `;
+      });
+    }
+
+    if (this.whereOptions.length > 0) {
+      this.whereOptions.reduce((prefix: string, option) => {
+        if (typeof option.equalValue === 'string') {
+          sql += ` ${prefix} ${option.column} = '${option.equalValue}'`;
+        } else {
+          sql += ` ${prefix} ${option.column} = ${option.equalValue}`;
+        }
+
+        return 'AND';
+      }, 'WHERE');
+    }
+
+    if (this.orderByOptions.length > 0) {
+      sql += ` ORDER BY `;
+      this.orderByOptions.forEach(option => {
+        sql += ` ${option.column} ${option.type} `;
+      });
+    }
+
+    return sql;
+  }
+}
+
+export default SelectSQLGenerator;


### PR DESCRIPTION
#### 사용방법

```typescript
const gen = new SelectSQLGenerator('product', '*');
gen.addWhere({
  column: 'id',
  equalValue: 1,
});
gen.addWhere({
  column: 'name',
  equalValue: 'hello',
});
gen.addJoin({
  joinTable: 'user',
  type: 'LEFT JOIN',
  joinPK: 'id',
  equalColum: 'product.userId',
});
gen.addOrderBy({
  type: 'DESC',
  column: 'createdAt',
});

console.log(gen.generate());
```