### PR TITLE
feat: 프론트엔드 메시지 읽기 기능 추가

### DIFF
--- a/backend/src/services/chat-room.service.ts
+++ b/backend/src/services/chat-room.service.ts
@@ -4,6 +4,7 @@ import chatMessageQuery from '../query/chat-message.query';
 import chatRoomQuery from '../query/chat-room.query';
 import productImageQuery from '../query/product-image.query';
 import productQuery from '../query/product.query';
+import readChatMessageQuery from '../query/read-chat-message.query';
 
 class ChatroomService {
 
@@ -53,10 +54,17 @@ class ChatroomService {
         .then(image => {
           image = image;
 
+          return readChatMessageQuery.select(
+            `SELECT * FROM read_chat_message WHERE userId = ? AND chatRoomId = ? LIMIT 1`, [userId, chatRoom.id]);
+        })
+        .then(lastReadChatMessage => {
+          let chatMessageId = 0;
+          if (lastReadChatMessage.length > 0) {
+            chatMessageId = lastReadChatMessage[0].chatMessageId;
+          }
+
           return chatMessageQuery.count(`
-          SELECT COUNT(*) FROM chat_message WHERE id > (
-            SELECT chatMessageId FROM read_chat_message WHERE userId = ? AND chatRoomId = ? LIMIT 1
-          ) AND chatRoomId = ?`, [userId, chatRoom.id, chatRoom.id]);
+          SELECT COUNT(*) FROM chat_message WHERE id > ? AND chatRoomId = ?`, [chatMessageId, chatRoom.id]);
         })
         .then(count => {
           return {

--- a/frontend/src/components/Chat/ChatProduct/index.ts
+++ b/frontend/src/components/Chat/ChatProduct/index.ts
@@ -1,6 +1,7 @@
 import { SpecificChatRoomTypes } from '../../../types/chatRoom';
 import { formatPrice } from '../../../util/price';
 import React from '../../../util/react';
+import { $ } from '../../../util/select';
 
 import './index.css';
 
@@ -30,12 +31,20 @@ export default class ChatProduct extends React {
       <div class="ChatProduct-Status">${this.chatRoom.product.isSoldOut ? '판매완료' : '판매중'}</div>
     </div>
     `
+
+    this.methods();
   }
 
   css() {
     return ``
   }
 
-  methods() {}
+  onChatProductClicked = () => {
+    location.href = `/#product/${this.chatRoom.productId}`;
+  }
+
+  methods() {
+    $('.ChatProduct').on('click', this.onChatProductClicked);
+  }
 
 }

--- a/frontend/src/components/Chat/index.ts
+++ b/frontend/src/components/Chat/index.ts
@@ -16,6 +16,7 @@ import { SpecificChatRoomTypes } from '../../types/chatRoom';
 import './Chat.css';
 import { ChatMessageTypes } from '../../types/chatMessage';
 import LeaveChatModal from './LeaveChatModal';
+import { redux } from '../..';
 
 const NEW_CHAT_NOTICE_SHOWING_TIME = 5000;
 
@@ -77,11 +78,15 @@ export default class Chat extends React {
     }
   }
 
+  onGoBackClicked = () => {
+    redux.router.goRouter();
+  }
+
   onLeaveButtonClicked = () => {
     // 현재 채팅방 조회로 대치
     leaveChatRoom(this.chatRoom.id)
       .then(() => {
-        // 홈으로 돌아가기
+        redux.router.goRouter();
       })
       .catch(error => {
         // error handling
@@ -242,6 +247,7 @@ export default class Chat extends React {
     $('#Chat-Message-Input').on('keypress', this.onChatMessageInputKeyPressed);
     $('#Open-Leave-Chat-Modal-Button').on('click', this.onOpenLeaveChatModalButtonClicked);
     $('.New-Chat-Notice').on('click', this.onNewChatNoticeClicked);
+    $('#Chat-Go-Back').on('click', this.onGoBackClicked);
   }
 
   render(): void {
@@ -249,7 +255,7 @@ export default class Chat extends React {
       <div id="Chat-Inner">
         <header>
           <div class="Chat-Header">
-            <div class="Header-Left">${LeftArrow}</div>
+            <div class="Header-Left"><span id="Chat-Go-Back">${LeftArrow}<span></div>
             <h4 class="ChatRoom-Title"></h4>
             <div class="Header-Right" id="Open-Leave-Chat-Modal-Button">${Logout}</div>
           </div>

--- a/frontend/src/components/ChatRoom/ChatRoomItem/index.css
+++ b/frontend/src/components/ChatRoom/ChatRoomItem/index.css
@@ -40,6 +40,7 @@
 
 .ChatRoomItem-Partner {
   color: #222222;
+  font-weight: normal;
   margin-bottom: 2px;
 }
 
@@ -75,17 +76,17 @@
   font-weight: normal;
   color: #888888;
   margin-bottom: 2px;
+  font-size: 12px;
 }
 
 .RecentMessage-Count {
-  display: flex;
-  align-items: center;
-  justify-content: center;
   background-color: #2AC1BC;
   font-weight: normal;
   color: #ffffff;
-  width: 25px;
-  height: 25px;
-  border-radius: 50%;
+  height: 20px;
+  min-width: 20px;
+  padding: 4px;
+  border-radius: 999px;
   margin-top: 2px;
+  font-size: 12px;
 }

--- a/frontend/src/components/ChatRoom/ChatRoomItem/index.ts
+++ b/frontend/src/components/ChatRoom/ChatRoomItem/index.ts
@@ -28,7 +28,7 @@ export default class ChatRoomItem extends React {
 
           <div class="ChatRoomItem-RecentMessage-Info">
             <span class="RecentMessage-Time">${recentMessage.createdAt !== null ? formatCreatedAt(recentMessage.createdAt) : ''}</span>
-            <div class="RecentMessage-Count">2</div>
+            ${this.chatRoom.newMessageCount > 0 ? `<div class="RecentMessage-Count">${this.chatRoom.newMessageCount}</div>` : ''}
           </div>
         </div>
 

--- a/frontend/src/components/ChatRoom/ChatRoomList/index.ts
+++ b/frontend/src/components/ChatRoom/ChatRoomList/index.ts
@@ -43,7 +43,7 @@ export default class ChatRoomList extends React {
       })
       .catch(error => {
         // error handling
-      })
+      });
   }
 
   render(): void {

--- a/frontend/src/components/Product/ProductContainer/ProductContainer.ts
+++ b/frontend/src/components/Product/ProductContainer/ProductContainer.ts
@@ -7,8 +7,9 @@ import { LeftArrow } from "../../../svgicon/LeftArrow"
 import { $ } from "../../../util/select"
 import { redux } from "../../.."
 import { BLocationSVG } from "../../../svgicon/location"
+import { joinChatRoom } from '../../../requests/chatRoom'
 
-export default class ProductContainer extends React{
+export default class ProductContainer extends React {
 
     productId = ""
     product: ProductTypes
@@ -145,7 +146,7 @@ export default class ProductContainer extends React{
                     <div>
                     </div>
                 </div>
-                <img src="${this.product.productImages? this.product.productImages[0].filePath : 'public/image/shoes.jpg'}" class="product-images" />
+                <img src="${this.product.productImages ? this.product.productImages[0].filePath : 'public/image/shoes.jpg'}" class="product-images" />
                 <div id="product-content" >
                     <h3 class="product-title" >${this.product.title}</h3>
                     <h3 class="product-time" >기타 중고물품 - ${getTimes().getTime(this.product.createdAt)}</h3>    
@@ -165,6 +166,8 @@ export default class ProductContainer extends React{
                         <h5 class="product-user-town" >${this.product.town.townName}</h5>
                     </div>
                 </div>
+
+                <button id="chat-product-button">문의하기</button>
             </div>
         `
     }
@@ -173,7 +176,19 @@ export default class ProductContainer extends React{
         redux.router.goRouter()
     }
 
+    onChatProductButtonClicked = () => {
+        joinChatRoom(this.product.id)
+            .then(data => {
+                const { chatRoom } = data.data;
+                location.href = `/#chat/${chatRoom.id}`;
+            })
+            .catch(error => [
+                // error handling
+            ])
+    }
+
     methods() {
         $("#Product-Top-Back").on("click", this.goBack)
+        $('#chat-product-button').on('click', this.onChatProductButtonClicked);
     }
 }

--- a/frontend/src/requests/chatMessage.ts
+++ b/frontend/src/requests/chatMessage.ts
@@ -33,3 +33,16 @@ export const sendChatMessage = (chatRoomId: number, content: string): Promise<an
     }),
   });
 }
+
+export const readChatMessage = (chatRoomId: number, chatMessageId: number): Promise<any> => {
+  return fetchThen(`/api/chat-message/read/${chatRoomId}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${cache.get('token').value}`,
+    },
+    body: JSON.stringify({
+      chatMessageId,
+    }),
+  });
+}

--- a/frontend/src/requests/chatRoom.ts
+++ b/frontend/src/requests/chatRoom.ts
@@ -30,3 +30,13 @@ export const leaveChatRoom = (id: number): Promise<any> => {
     },
   });
 }
+
+export const joinChatRoom = (productId: number): Promise<any> => {
+  return fetchThen(`/api/chat-room/join/${productId}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${cache.get('token').value}`,
+    },
+  });
+}

--- a/frontend/src/types/chatRoom.ts
+++ b/frontend/src/types/chatRoom.ts
@@ -21,5 +21,6 @@ export type ChatRoomTypes = SpecificChatRoomTypes & {
   recentMessage: {
     content: string;
     createdAt: string;
-  }
+  },
+  newMessageCount: number;
 }

--- a/frontend/src/types/chatRoom.ts
+++ b/frontend/src/types/chatRoom.ts
@@ -4,6 +4,7 @@ export type SpecificChatRoomTypes = {
   id: number;
   productId: number;
   product: {
+    id: number;
     title: string;
     price: number | null;
     isSoldOut: number;


### PR DESCRIPTION
## 프론트엔드 메시지 읽기 기능 및 문의하기 버튼동작


### 작업사항

- 메시지 `interval fetch` 후 `read API` 를 호출하여 읽음 처리
- 읽지 않음 메시지 개수를 채팅방 리스트에 보여줌
- 문의하기 버튼을 통해 채팅방 입장



### 병합 후 작업사항 / 주의사항

- 없음

### 간단 설명

문의하기 버튼은 스타일링 되어있지 않으며 자신의 상품일 경우 다른 버튼으로 대체되는 처리가 되어있지 않음

기존의 __채팅 페이지를 빠져나올때__ `read API`를 호출하지 않고 **메시지를 `fetch` 할때마다 호출**하는 이유는 `hashchange` 이벤트가 페이지가 전환된 후 발생하여 `read API`가 호출되기 전 채팅방 리스트로 이동되며 채팅방 리스트가 `fetch`되기 때문에 새로운 메시지 개수가 옳지 않기 때문

### 개발 UI

<img width="411" alt="스크린샷 2021-07-20 오후 7 42 33" src="https://user-images.githubusercontent.com/49791336/126311414-e270b01b-dfe1-4b64-83d9-b01728a4f896.png">
<img width="415" alt="스크린샷 2021-07-20 오후 7 43 06" src="https://user-images.githubusercontent.com/49791336/126311420-e4f310e7-71b4-4d7a-a057-09a6604e8aea.png">
